### PR TITLE
add Content-type header

### DIFF
--- a/src/store/modules/searchx.js
+++ b/src/store/modules/searchx.js
@@ -28,7 +28,11 @@ const searchx = {
   },
   actions: {
     CURLSerachResult ({commit}, body) {
-      Vue.http.post(body.url, body)
+      Vue.http.post(body.url, body, {
+          headers: {
+              "Content-Type": "application/json"
+          }
+      })
       .then(
         response => {
           commit('SET_SHOW_SPINNER', false)


### PR DESCRIPTION
DSL need content-type header
```json
{
"info": "2019-05-15 10:08:20.796891167 +0800 CST: Error [Content-Type header [] is not supported] Status [406] [406]"
}
```